### PR TITLE
--proxy-user flag added

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 const defaultPort = "1080"
@@ -21,4 +23,32 @@ func proxyCmd(proxy string) (string, error) {
 		proxy += defaultPort
 	}
 	return proxy, nil
+}
+
+// proxyUserCmd handles "--proxy-user" related tasks. Returns
+// encoded with Base64 string.
+func proxyUserCmd(proxyUser string) (string, error) {
+	err := checkProxyUser(proxyUser)
+	if err != nil {
+		return "", err
+	}
+	if !proxyNTLM && !proxyNegotiate && !proxyDigest { // Basic auth
+		encodedProxy := convertBasicAuth(proxyUser)
+		return encodedProxy, nil
+	}
+	return proxyUser, nil
+}
+
+// checkProxyUser controls proxyUser whether is in <username:password> format.
+func checkProxyUser(proxyUser string) error {
+	p := strings.Split(proxyUser, ":")
+	if len(p) != 2 || len(p[0]) == 0 || len(p[1]) == 0 {
+		return fmt.Errorf("need to specify username and password in <username:password> format")
+	}
+	return nil
+}
+
+// convertBasicAuth encodes proxy username and password to Base64.
+func convertBasicAuth(proxyUser string) string {
+	return base64.StdEncoding.EncodeToString([]byte(proxyUser))
 }

--- a/cmd/proxy_test.go
+++ b/cmd/proxy_test.go
@@ -1,14 +1,19 @@
 package cmd
 
 import (
+	"log"
 	"testing"
 )
 
 const (
-	proxyUrl            = "proxy://myproxy:1234"
-	httpProxyUrl        = "http://myproxy:1234"
-	missingProxyUrl     = "proxy://proxy"
-	missingHTTPProxyUrl = "http://myproxy"
+	proxyUrl             = "proxy://myproxy:1234"
+	httpProxyUrl         = "http://myproxy:1234"
+	missingProxyUrl      = "proxy://proxy"
+	missingHTTPProxyUrl  = "http://myproxy"
+	validProxyUser       = "user:pass"
+	emptyPassProxyUser   = "user:"
+	emptyUserProxyUser   = ":pass"
+	invalidProxyUserLong = "user:pass1:pass2"
 )
 
 func TestProxyCmd_ProxyUrl(t *testing.T) {
@@ -50,5 +55,62 @@ func TestProxyCmd_MissingHTTPProxyUrl(t *testing.T) {
 	}
 	if testProxyUrl != expectedUrl {
 		t.Errorf("wrong proxy url. expected url: %s, got: %s", expectedUrl, testProxyUrl)
+	}
+}
+
+func TestCheckValidProxyUser(t *testing.T) {
+	err := checkProxyUser(validProxyUser)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+func TestCheckEmptyUserProxyUser(t *testing.T) {
+	err := checkProxyUser(emptyUserProxyUser)
+	if err == nil {
+		t.Errorf("empyt username.")
+	}
+}
+
+func TestCheckEmptyPassProxyUser(t *testing.T) {
+	err := checkProxyUser(emptyPassProxyUser)
+	if err == nil {
+		t.Errorf("invalid password.")
+	}
+}
+
+func TestCheckEmptyProxyUser(t *testing.T) {
+	err := checkProxyUser("")
+	if err == nil {
+		t.Errorf("empty user")
+	}
+}
+
+func TestCheckLongProxyUser(t *testing.T) {
+	err := checkProxyUser(invalidProxyUserLong)
+	if err == nil {
+		t.Errorf("long proxy user")
+	}
+}
+
+func TestProxyUserCmdBasic(t *testing.T) {
+	proxyUserCredential, err := proxyUserCmd(validProxyUser)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if proxyUserCredential == validProxyUser {
+		t.Errorf("proxy user: <%s> should not be the same with <%s>", validProxyUser, proxyUserCredential)
+	}
+	log.Printf("proxy user credential: %s", proxyUserCredential)
+}
+
+func TestProxyUserCmdDigest(t *testing.T) {
+	proxyDigest = true
+	proxyUserCredential, err := proxyUserCmd(validProxyUser)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if proxyUserCredential != validProxyUser {
+		t.Errorf("proxy user: <%s> should be the same with <%s>", validProxyUser, proxyUserCredential)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,32 @@ import (
 )
 
 var (
-	URL   = ""
+	// URL is the target address.
+	URL = ""
+
+	// proxy is the url in the format of [protocol://]host[:port]. Its flag is
+	// --proxy [protocol://]host[:port] or -x [protocol://]host[:port].
 	proxy = ""
-	c     = src.NewClient()
+
+	// proxyUser is the username-password pair in <user:password> format. Its flag is
+	// --proxy-user <user:password>.
+	proxyUser = ""
+
+	// proxyBasic is the flag variable whether indicates command contains --proxy-basic flag.
+	// Basic is also the default unless anything else is asked for.
+	proxyBasic = true
+
+	// proxyDigest is the flag variable whether indicates command contains --proxy-digest flag.
+	proxyDigest = false
+
+	// proxyNTLM is the flag variable whether indicates command contains --proxy-ntlm flag.
+	proxyNTLM = false
+
+	// proxyNegotiate is the flag variable whether indicates command contains --proxy-negotiate flag.
+	proxyNegotiate = false
+
+	// c is the client.
+	c = src.NewClient()
 )
 
 var rootCmd = &cobra.Command{
@@ -31,6 +54,11 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	rootCmd.AddCommand(cmdGet)
 	rootCmd.PersistentFlags().StringVarP(&proxy, "proxy", "x", "", "[protocol://]host[:port] Use this proxy")
+	rootCmd.PersistentFlags().StringVarP(&proxyUser, "proxy-user", "U", "", "<user:password> Proxy user and password")
+	rootCmd.PersistentFlags().BoolVarP(&proxyBasic, "proxy-basic", "", true, "Use Basic authentication on the proxy")
+	rootCmd.PersistentFlags().BoolVarP(&proxyDigest, "proxy-digest", "", false, "Use Digest authentication on the proxy")
+	rootCmd.PersistentFlags().BoolVarP(&proxyNTLM, "proxy-ntlm", "", false, "Use NTLM authentication on the proxy")
+	rootCmd.PersistentFlags().BoolVarP(&proxyNegotiate, "proxy-negotiate", "", false, "Use HTTP Negotiate (SPNEGO) authentication on the proxy")
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -45,6 +73,15 @@ func checkFlags() error {
 			return err
 		}
 		c.SetProxy(proxy)
+	}
+	if proxyUser != "" {
+		proxyUserCredentials, err := proxyUserCmd(proxyUser)
+		if err != nil {
+			return err
+		}
+		if !proxyNTLM && !proxyNegotiate && !proxyDigest { // Basic authentication
+			c.AddHeader("Proxy-Authenticate", fmt.Sprintf("Basic %s", proxyUserCredentials))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
* tests added for functions
* flags added for auth options (basic, digest, ntlm, negotiate). But not implemented yet. 
* comment lines added
* `<username:password>` encoded to `base64` for `--proxy-basic`. 

## Changes

`--proxy-user <user:pass>` flag added. In default, this flag uses **Basic auth**. But, there are other auth methods like **digest, ntlm,** etc. That's why I added `proxy-basic, --proxy-digest, --proxy-ntlm, --proxy-negotiate` flags. But, these are except `--proxy-basic` have not implemented yet. 

## Reference
* https://curl.se/docs/manpage.html#-U 
* https://daniel.haxx.se/blog/2020/03/30/curl-ootw-proxy-basic/

## Usage 

```shell
Flags:
  -h, --help                help for gURL
  -x, --proxy string        [protocol://]host[:port] Use this proxy
      --proxy-basic         Use Basic authentication on the proxy (default true)
      --proxy-digest        Use Digest authentication on the proxy
      --proxy-negotiate     Use HTTP Negotiate (SPNEGO) authentication on the proxy
      --proxy-ntlm          Use NTLM authentication on the proxy
  -U, --proxy-user string   <user:password> Proxy user and password

```

## Example Usage

```shell
$ gurl --proxy-user user:pass --proxy http://proxy.com:2343 www.google.com 
$ gurl --proxy-user user:pass  --proxy-basic --proxy http://proxy.com:2343 www.google.com 
$ gurl --proxy-user user:pass --proxy http://proxy.com:2343 www.google.com --proxy-digest
```